### PR TITLE
Add default cargo `.gigitnore` to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock


### PR DESCRIPTION
I noticed this was missing when almost accidentally committing the
`target` directory and `Cargo.lock` in #1.