### PR TITLE
Improve HRIR load times by reusing the resampler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ readme = "README.md"
 [dependencies]
 rustfft = "6.0.1"
 byteorder = "1.3.4"
-rubato = "0.10.0"
+rubato = "0.14.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -910,7 +910,7 @@ impl HrtfProcessor {
     ///
     /// let mut processor = HrtfProcessor::new(hrir_sphere, 8, 128);
     ///
-    /// let source = vec![0; 1024]; // Fill with something useful.
+    /// let source = vec![0.; 1024]; // Fill with something useful.
     /// let mut output = vec![(0.0, 0.0); 1024];
     /// let mut prev_left_samples = vec![];
     /// let mut prev_right_samples = vec![];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,16 +269,17 @@ fn resample_hrir(hrir: Vec<f32>, ratio: f64) -> Vec<f32> {
     if ratio.eq(&1.0) {
         hrir
     } else {
-        let params = rubato::InterpolationParameters {
+        let params = rubato::SincInterpolationParameters {
             sinc_len: 256,
             f_cutoff: 0.95,
             oversampling_factor: 160,
-            interpolation: rubato::InterpolationType::Cubic,
+            interpolation: rubato::SincInterpolationType::Cubic,
             window: rubato::WindowFunction::BlackmanHarris2,
         };
 
-        let mut resampler = rubato::SincFixedIn::<f32>::new(ratio, params, hrir.len(), 1);
-        let result = resampler.process(&[hrir]).unwrap();
+        let mut resampler =
+            rubato::SincFixedIn::<f32>::new(ratio, 1.0, params, hrir.len(), 1).unwrap();
+        let result = resampler.process(&[hrir], None).unwrap();
         result.into_iter().next().unwrap()
     }
 }


### PR DESCRIPTION
Hello and thanks for providing this library. We are happily using it in our project web-audio-api-rs.
We are currently investigating HRTF processor load times over at https://github.com/orottier/web-audio-api-rs/issues/371 
This PR improves initial load time from 300ms to 45ms on my machine (Apple M1) when resampling a HRIR sphere from 44100 Hz to 48000.
I also performed some housekeeping (rubato update, fix doctest) which I can leave out if you think it adds noise.